### PR TITLE
fix(capacitor.config.ts): correct webDir path for build output

### DIFF
--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -23,7 +23,7 @@ jobs:
       tool: "npm"
       lint: "run affected:lint"
       test: "run affected:test"
-      build_branch: "run affected:build"
+      build_branch: "run build --skip-nx-cache"
       build_main: "run build --skip-nx-cache"
       post_build_script: "run sync"
       app_root: "apps/numveil"

--- a/apps/numveil/capacitor.config.ts
+++ b/apps/numveil/capacitor.config.ts
@@ -3,7 +3,7 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'de.tehwolf',
   appName: 'Numveil',
-  webDir: '../dist/numveil/browser',
+  webDir: '../../dist/numveil/browser',
   server: {
     androidScheme: 'https',
   },


### PR DESCRIPTION
* Updated the `webDir` path to ensure it points to the correct directory for the browser build output.
