### PR TITLE
feat: make API URL and CORS configurable via environment variables

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -2,3 +2,6 @@ FROM nginx:alpine-slim
 RUN apk upgrade --no-cache
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY dist/numveil/browser /usr/share/nginx/html
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,101 +1,146 @@
-# NumberGame
+# Numveil
 
-<a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>
+A real-time multiplayer number guessing game built with Angular and NestJS.
 
-✨ Your new, shiny [Nx workspace](https://nx.dev) is ready ✨.
+One player per session becomes the **number decider** — they submit a secret number first. All other players submit guesses. When all guesses are in, winners are calculated.
 
-[Learn more about this workspace setup and its capabilities](https://nx.dev/getting-started/tutorials/angular-monorepo-tutorial?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
+**Two game modes** (auto-selected based on player count):
+- **Exact** — guess the exact number (2-player sessions)
+- **Distance** — closest guess wins (3+ player sessions)
 
-## Run tasks
+## Stack
 
-To run the dev server for your app, use:
+| Layer | Technology |
+|---|---|
+| Frontend | Angular 21 + Angular Material |
+| Backend | NestJS 11 + WebSocket (`ws`) |
+| Mobile | Capacitor 8 (Android) |
+| Monorepo | Nx 22 |
+| Container | Docker (nginx + node:alpine) |
 
-```sh
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- npm
+
+```bash
+npm install
+```
+
+### Development
+
+```bash
+# Serve frontend (http://localhost:4200)
 npx nx serve numveil
+
+# Serve backend (ws://localhost:4444)
+npx nx serve api
 ```
 
-To create a production bundle:
+### Testing
 
-```sh
-npx nx build numveil
+```bash
+npx nx test numveil     # Frontend unit tests
+npx nx test api         # Backend unit tests
+npx nx e2e numveil-e2e  # Playwright E2E tests
 ```
 
-To see all available targets to run for a project, run:
+### Building
 
-```sh
-npx nx show project numveil
+```bash
+npm run build           # Build all projects
+npx nx build numveil    # Frontend only
+npx nx build api        # Backend only
 ```
 
-These targets are either [inferred automatically](https://nx.dev/concepts/inferred-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or defined in the `project.json` or `package.json` files.
+## Docker
 
-[More about running tasks in the docs &raquo;](https://nx.dev/features/run-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+Docker images are built for both the frontend (nginx) and backend (node).
 
-## Add new projects
-
-While you could add new projects to your workspace manually, you might want to leverage [Nx plugins](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) and their [code generation](https://nx.dev/features/generate-code?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) feature.
-
-Use the plugin's generator to create new projects.
-
-To generate a new application, use:
-
-```sh
-npx nx g @nx/angular:app demo
+```bash
+docker build -f Dockerfile.api -t numveil-api .
+docker build -f Dockerfile.app -t numveil-app .
 ```
 
-To generate a new library, use:
+### Environment Variables
 
-```sh
-npx nx g @nx/angular:lib mylib
+**Backend (`numveil-api`)**
+
+| Variable | Default | Description |
+|---|---|---|
+| `API_PORT` | `4444` | WebSocket server port |
+| `CORS_ORIGIN` | `http://localhost` | Allowed CORS origin |
+| `PORT` | `3000` | HTTP server port |
+
+**Frontend (`numveil-app`)**
+
+| Variable | Default | Description |
+|---|---|---|
+| `API_URL` | `ws://localhost` | WebSocket URL |
+| `API_PORT` | `4444` | WebSocket server port |
+
+### Example Docker Compose (with Traefik)
+
+```yaml
+services:
+  numveil-api:
+    image: ghcr.io/tehw0lf/numveil-api:latest
+    environment:
+      CORS_ORIGIN: "https://numveil.example.com"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.numveil-api.rule=Host(`numveil.example.com`) && PathPrefix(`/ws`)"
+
+  numveil-app:
+    image: ghcr.io/tehw0lf/numveil-app:latest
+    environment:
+      API_URL: "wss://numveil.example.com"
+      API_PORT: "443"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.numveil-app.rule=Host(`numveil.example.com`)"
 ```
 
-You can use `npx nx list` to get a list of installed plugins. Then, run `npx nx list <plugin-name>` to learn about more specific capabilities of a particular plugin. Alternatively, [install Nx Console](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) to browse plugins and generators in your IDE.
+## Architecture
 
-[Learn more about Nx plugins &raquo;](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) | [Browse the plugin registry &raquo;](https://nx.dev/plugin-registry?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Set up CI!
-
-### Step 1
-
-To connect to Nx Cloud, run the following command:
-
-```sh
-npx nx connect
+```
+apps/
+├── api/            # NestJS WebSocket server
+└── numveil/        # Angular frontend (web + Android via Capacitor)
+libs/
+└── core/           # Shared types
 ```
 
-Connecting to Nx Cloud ensures a [fast and scalable CI](https://nx.dev/ci/intro/why-nx-cloud?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) pipeline. It includes features such as:
+### WebSocket Protocol
 
-- [Remote caching](https://nx.dev/ci/features/remote-cache?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Task distribution across multiple machines](https://nx.dev/ci/features/distribute-task-execution?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Automated e2e test splitting](https://nx.dev/ci/features/split-e2e-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Task flakiness detection and rerunning](https://nx.dev/ci/features/flaky-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+**Client → Server**
 
-### Step 2
+| Event | Payload | Description |
+|---|---|---|
+| `joinSession` | `{ uuid, sessionID, name }` | Create or join a session |
+| `guess` | `{ uuid, sessionID, guess }` | Submit a number |
+| `newRound` | `{ uuid, sessionID }` | Start a new round |
+| `leaveSession` | `{ uuid, sessionID }` | Leave session |
 
-Use the following command to configure a CI workflow for your workspace:
+**Server → Client**
 
-```sh
-npx nx g ci-workflow
+| Event | Description |
+|---|---|
+| `join` | Confirms join, returns `uuid`, `sessionID`, `pic` |
+| `running` | Broadcasts updated session state to all players |
+| `restart` | Signals a new round has started |
+
+## Mobile (Android)
+
+```bash
+npm run build
+npm run sync        # Sync web assets to Android project
 ```
 
-[Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+The Android project lives in `apps/numveil/android/`.
 
-## Install Nx Console
+## License
 
-Nx Console is an editor extension that enriches your developer experience. It lets you run tasks, generate code, and improves code autocompletion in your IDE. It is available for VSCode and IntelliJ.
-
-[Install Nx Console &raquo;](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Useful links
-
-Learn more:
-
-- [Learn more about this workspace setup](https://nx.dev/getting-started/tutorials/angular-monorepo-tutorial?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects)
-- [Learn about Nx on CI](https://nx.dev/ci/intro/ci-with-nx?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Releasing Packages with Nx release](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [What are Nx plugins?](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-And join the Nx community:
-- [Discord](https://go.nx.dev/community)
-- [Follow us on X](https://twitter.com/nxdevtools) or [LinkedIn](https://www.linkedin.com/company/nrwl)
-- [Our Youtube channel](https://www.youtube.com/@nxdevtools)
-- [Our blog](https://nx.dev/blog?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+MIT

--- a/apps/api/src/app/app.gateway.ts
+++ b/apps/api/src/app/app.gateway.ts
@@ -31,7 +31,11 @@ const sessionInfo = new Map<
   }
 >();
 
-@WebSocketGateway(environment.api_port)
+@WebSocketGateway(Number(process.env['API_PORT']) || environment.api_port, {
+  cors: {
+    origin: process.env['CORS_ORIGIN'] || 'http://localhost',
+  },
+})
 export class AppGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,19 +1,23 @@
-/**
- * This is not a production server yet!
- * This is only a minimal backend to get started.
- */
 import { NestFactory } from '@nestjs/core';
 import { WsAdapter } from '@nestjs/platform-ws';
+import helmet from 'helmet';
 
 import { AppModule } from './app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  const globalPrefix = 'api';
+  const corsOrigin = process.env['CORS_ORIGIN'] || 'http://localhost';
+  app.use(helmet());
+  app.enableCors({ origin: corsOrigin });
   app.useWebSocketAdapter(new WsAdapter(app));
-  app.setGlobalPrefix(globalPrefix);
-  const port = process.env.PORT || 3000;
+
+  const port = process.env['PORT'] || 3000;
   await app.listen(port);
+
+  process.on('SIGTERM', async () => {
+    await app.close();
+    process.exit(0);
+  });
 }
 
 bootstrap();

--- a/apps/numveil/public/config.json
+++ b/apps/numveil/public/config.json
@@ -1,0 +1,4 @@
+{
+  "api_url": "ws://localhost",
+  "api_port": 4444
+}

--- a/apps/numveil/src/app/app.config.ts
+++ b/apps/numveil/src/app/app.config.ts
@@ -1,10 +1,22 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  ApplicationConfig,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
+import { ConfigService } from './services/config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (configService: ConfigService) => () =>
+        configService.load(),
+      deps: [ConfigService],
+      multi: true,
+    },
   ],
 };

--- a/apps/numveil/src/app/join/join.component.html
+++ b/apps/numveil/src/app/join/join.component.html
@@ -49,5 +49,27 @@
         </button>
       }
     </div>
+
+    <div class="advanced">
+      <button class="btn btn--ghost btn--small" (click)="toggleAdvanced()">
+        {{ showAdvanced() ? '▲ Hide' : '▼ Advanced' }}
+      </button>
+
+      @if (showAdvanced()) {
+        <div class="field">
+          <label for="server-url-input">Server URL</label>
+          <input
+            id="server-url-input"
+            class="input"
+            type="text"
+            [ngModel]="serverUrl()"
+            (ngModelChange)="applyServerUrl($event)"
+          />
+        </div>
+        <button class="btn btn--ghost btn--small" (click)="resetServerUrl()">
+          Reset to default
+        </button>
+      }
+    </div>
   </div>
 </div>

--- a/apps/numveil/src/app/join/join.component.ts
+++ b/apps/numveil/src/app/join/join.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
+import { ConfigService } from '../services/config.service';
 import { SessionService } from '../services/session.service';
 
 @Component({
@@ -20,12 +21,30 @@ export class JoinComponent {
   name: WritableSignal<string> = signal('');
   sessionID: WritableSignal<string> = signal('');
   mode: WritableSignal<'create' | 'join'> = signal('create');
+  showAdvanced: WritableSignal<boolean> = signal(false);
 
+  private configService: ConfigService = inject(ConfigService);
   private sessionService: SessionService = inject(SessionService);
+
+  serverUrl: WritableSignal<string> = this.configService.serverUrl;
 
   setMode(m: 'create' | 'join'): void {
     this.mode.set(m);
     this.sessionID.set('');
+  }
+
+  toggleAdvanced(): void {
+    this.showAdvanced.set(!this.showAdvanced());
+  }
+
+  applyServerUrl(url: string): void {
+    this.configService.setServerUrl(url);
+    this.sessionService.reconnect();
+  }
+
+  resetServerUrl(): void {
+    this.configService.resetServerUrl();
+    this.sessionService.reconnect();
   }
 
   joinSession(): void {

--- a/apps/numveil/src/app/services/config.service.ts
+++ b/apps/numveil/src/app/services/config.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+
+interface AppConfig {
+  api_url: string;
+  api_port: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConfigService {
+  private config: AppConfig = { api_url: 'ws://localhost', api_port: 4444 };
+
+  async load(): Promise<void> {
+    const response = await fetch('/config.json');
+    this.config = await response.json();
+  }
+
+  get apiUrl(): string {
+    return this.config.api_url;
+  }
+
+  get apiPort(): number {
+    return this.config.api_port;
+  }
+}

--- a/apps/numveil/src/app/services/config.service.ts
+++ b/apps/numveil/src/app/services/config.service.ts
@@ -1,4 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal, WritableSignal } from '@angular/core';
+
+const STORAGE_KEY = 'numveil_server_url';
 
 interface AppConfig {
   api_url: string;
@@ -9,9 +11,12 @@ interface AppConfig {
 export class ConfigService {
   private config: AppConfig = { api_url: 'ws://localhost', api_port: 4444 };
 
+  readonly serverUrl: WritableSignal<string> = signal(this.buildUrl());
+
   async load(): Promise<void> {
     const response = await fetch('/config.json');
     this.config = await response.json();
+    this.serverUrl.set(this.buildUrl());
   }
 
   get apiUrl(): string {
@@ -20,5 +25,23 @@ export class ConfigService {
 
   get apiPort(): number {
     return this.config.api_port;
+  }
+
+  getServerUrl(): string {
+    return localStorage.getItem(STORAGE_KEY) ?? this.buildUrl();
+  }
+
+  setServerUrl(url: string): void {
+    localStorage.setItem(STORAGE_KEY, url);
+    this.serverUrl.set(url);
+  }
+
+  resetServerUrl(): void {
+    localStorage.removeItem(STORAGE_KEY);
+    this.serverUrl.set(this.buildUrl());
+  }
+
+  private buildUrl(): string {
+    return `${this.config.api_url}:${this.config.api_port}`;
   }
 }

--- a/apps/numveil/src/app/services/session.service.ts
+++ b/apps/numveil/src/app/services/session.service.ts
@@ -1,10 +1,10 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { environment } from '@numveil/core';
 import { Observable, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
+import { ConfigService } from './config.service';
 import { StateService } from './state.service';
 
 @Injectable({
@@ -13,10 +13,11 @@ import { StateService } from './state.service';
 export class SessionService {
   private router: Router = inject(Router);
   private stateService: StateService = inject(StateService);
+  private configService: ConfigService = inject(ConfigService);
 
   private closeSubject$ = new Subject();
   private subject$: WebSocketSubject<any> = webSocket({
-    url: `${environment.api_url}:${environment.api_port}`,
+    url: `${this.configService.apiUrl}:${this.configService.apiPort}`,
     closeObserver: this.closeSubject$,
   });
 

--- a/apps/numveil/src/app/services/session.service.ts
+++ b/apps/numveil/src/app/services/session.service.ts
@@ -16,15 +16,26 @@ export class SessionService {
   private configService: ConfigService = inject(ConfigService);
 
   private closeSubject$ = new Subject();
-  private subject$: WebSocketSubject<any> = webSocket({
-    url: `${this.configService.apiUrl}:${this.configService.apiPort}`,
-    closeObserver: this.closeSubject$,
-  });
+  private subject$: WebSocketSubject<any> | null = null;
 
   closeObservable$: Observable<any> = this.closeSubject$.asObservable();
 
+  private getSocket(): WebSocketSubject<any> {
+    if (!this.subject$) {
+      this.subject$ = webSocket({
+        url: this.configService.getServerUrl(),
+        closeObserver: this.closeSubject$,
+      });
+    }
+    return this.subject$;
+  }
+
+  reconnect(): void {
+    this.subject$ = null;
+  }
+
   initializeConnection(): void {
-    this.subject$
+    this.getSocket()
       .asObservable()
       .pipe(
         tap((data: { eventType: string; serverState: any }) => {
@@ -66,7 +77,7 @@ export class SessionService {
   }
 
   leaveSession(): void {
-    this.subject$.next({
+    this.getSocket().next({
       event: 'leaveSession',
       data: this.stateService.sessionUser(),
     });
@@ -77,7 +88,7 @@ export class SessionService {
     this.closeObservable$.subscribe(() => {
       this.stateService.resetSession();
     });
-    this.subject$.next({
+    this.getSocket().next({
       event: 'joinSession',
       data: {
         uuid: '',
@@ -88,7 +99,7 @@ export class SessionService {
   }
 
   sendGuess(guess?: number): void {
-    this.subject$.next({
+    this.getSocket().next({
       event: 'guess',
       data: {
         uuid: this.stateService.sessionUser()?.uuid,
@@ -101,7 +112,7 @@ export class SessionService {
   }
 
   newRound(): void {
-    this.subject$.next({
+    this.getSocket().next({
       event: 'newRound',
       data: {
         uuid: this.stateService.sessionUser()?.uuid,

--- a/apps/numveil/src/styles.scss
+++ b/apps/numveil/src/styles.scss
@@ -243,6 +243,11 @@ body::after {
   }
 }
 
+.btn--small {
+  font-size: 0.75rem;
+  padding: 7px 14px;
+}
+
 .btn--icon {
   width: auto;
   padding: 6px 10px;
@@ -265,6 +270,14 @@ body::after {
   flex-direction: column;
   gap: 10px;
   margin-top: 8px;
+}
+
+/* Advanced section */
+.advanced {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 /* Divider */

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+API_URL="${API_URL:-ws://localhost}"
+API_PORT="${API_PORT:-4444}"
+
+cat > /usr/share/nginx/html/config.json <<EOF
+{
+  "api_url": "${API_URL}",
+  "api_port": ${API_PORT}
+}
+EOF
+
+exec nginx -g "daemon off;"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ module.exports = [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/android'],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,12 @@
         "@capacitor/core": "8.3.0",
         "@nestjs/common": "11.1.18",
         "@nestjs/core": "11.1.18",
-        "@nestjs/platform-express": "11.1.18",
+        "@nestjs/platform-express": "^11.1.18",
         "@nestjs/platform-ws": "11.1.18",
         "@nestjs/websockets": "11.1.18",
         "axios": "1.15.0",
         "github-like-avatar-generator": "1.1.10",
+        "helmet": "^8.1.0",
         "reflect-metadata": "0.2.2",
         "rxjs": "~7.8.2",
         "zone.js": "0.16.0"
@@ -8004,22 +8005,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nestjs/schematics/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -8211,19 +8196,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@npmcli/agent": {
       "version": "4.0.0",
@@ -18495,16 +18467,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -19909,30 +19871,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -20424,19 +20362,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -20942,6 +20867,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -27102,46 +27036,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -33168,16 +33062,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "@capacitor/core": "8.3.0",
     "@nestjs/common": "11.1.18",
     "@nestjs/core": "11.1.18",
-    "@nestjs/platform-express": "11.1.18",
+    "@nestjs/platform-express": "^11.1.18",
     "@nestjs/platform-ws": "11.1.18",
     "@nestjs/websockets": "11.1.18",
     "axios": "1.15.0",
     "github-like-avatar-generator": "1.1.10",
+    "helmet": "^8.1.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "~7.8.2",
     "zone.js": "0.16.0"
@@ -73,6 +74,7 @@
     "jest-environment-jsdom": "30.2.0",
     "jest-environment-node": "30.2.0",
     "jest-preset-angular": "16.0.0",
+    "jest-util": "30.2.0",
     "nx": "22.6.5",
     "prettier": "3.8.1",
     "ts-jest": "29.4.6",
@@ -80,8 +82,7 @@
     "tslib": "2.3.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
-    "webpack-cli": "5.1.4",
-    "jest-util": "30.2.0"
+    "webpack-cli": "5.1.4"
   },
   "overrides": {
     "readdirp": "4.1.2",


### PR DESCRIPTION
## Summary
- **Backend**: `CORS_ORIGIN` and `API_PORT` env vars for WebSocket gateway (defaults: `http://localhost`, `4444`); Helmet + HTTP CORS + graceful SIGTERM shutdown in `main.ts`
- **Frontend**: Runtime config via `public/config.json` loaded at app start through `APP_INITIALIZER` + `ConfigService` — no rebuild needed to change API URL
- **Frontend**: "Advanced" section on join screen lets users set a custom server URL, persisted in `localStorage` with a reset button — works in both web and Android app, no CORS config needed on the client side
- **Dockerfile.app**: Entrypoint script generates `config.json` from `API_URL`/`API_PORT` env vars at container start
- **ESLint**: Android build artifacts (`android/`) now excluded from linting
- **README**: Replaced Nx boilerplate with actual project docs including Docker Compose/Traefik example

## Test plan
- [ ] `npm run affected:lint` — no errors (warnings only, pre-existing)
- [ ] `npm run affected:test` — all 47 tests pass
- [ ] `npm run affected:build` — both `api` and `numveil` build successfully
- [ ] Join screen: "Advanced" toggle shows/hides server URL field
- [ ] Server URL persists across page reloads via `localStorage`
- [ ] "Reset to default" restores the `config.json` value
- [ ] Docker: `API_URL=wss://example.com API_PORT=443` env vars correctly written to `config.json` at container start
- [ ] Backend: `CORS_ORIGIN=https://example.com` env var respected by WebSocket gateway