### PR TITLE
fix: correct Traefik WebSocket routing and config URL handling

### DIFF
--- a/apps/numveil/src/app/services/config.service.ts
+++ b/apps/numveil/src/app/services/config.service.ts
@@ -42,6 +42,9 @@ export class ConfigService {
   }
 
   private buildUrl(): string {
+    if (!this.config.api_port) {
+      return this.config.api_url;
+    }
     return `${this.config.api_url}:${this.config.api_port}`;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "scripts": {
     "affected:lint": "nx affected:lint",


### PR DESCRIPTION
## Summary
- **ConfigService**: `buildUrl()` now omits the port suffix when `api_port` is empty — allows setting `API_URL=wss://example.com/ws` and `API_PORT=""` in Docker for Traefik deployments where the path is part of the URL

## Deployment note (not committed)
For Traefik, the `docker-compose.yml` should use:
- `traefik.http.services.numveil-api.loadbalancer.server.port=4444` (WS port, not HTTP)
- WebSocket upgrade headers middleware
- `API_URL=wss://yourdomain.com/ws` + `API_PORT=""` for the frontend

## Test plan
- [ ] `npm run affected:lint` — no errors
- [ ] `npm run affected:test` — all 47 tests pass  
- [ ] `npm run affected:build` — builds successfully