### PR TITLE
fix(security): add HTTP security headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,15 @@ http {
 
         listen 80;
 
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
         location / {
             root /usr/share/nginx/html;
             index  index.html;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary

- Adds 8 HTTP security headers to the nginx `server` block to address DAST findings (closes #35)
- Headers added: `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Permissions-Policy`, `Cross-Origin-Embedder-Policy`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, `Referrer-Policy`
- `Strict-Transport-Security` intentionally omitted — TLS termination is handled by Traefik upstream

## Test plan

- [ ] Verify nginx config syntax parses correctly in the deployment environment (`nginx -t`)
- [ ] Deploy and confirm security headers are present in HTTP responses (e.g. via browser DevTools or `curl -I`)
- [ ] Re-run DAST scan to confirm findings are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added HTTP security headers to server configuration, including Content Security Policy, clickjacking/mime-type protections, permissions policy, cross-origin protections, and referrer policy, applied to all responses.
* **Chores**
  * Bumped package version from 2.1.0 to 2.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->