### PR TITLE
fix(csp): add form-action and base-uri directives

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self';" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary

Adds `form-action 'none'` and `base-uri 'self'` to the Content-Security-Policy header.

These directives have no `default-src` fallback — if omitted, they are completely unrestricted. ZAP flags this as finding [10055] "CSP: Failure to Define Directive with No Fallback".

- `form-action 'none'` — no form submissions allowed (no forms in this app)
- `base-uri 'self'` — prevents base tag injection attacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by strengthening the Content Security Policy with additional directives to better protect against unauthorized form submissions and control resource base URIs.

* **Chores**
  * Version bumped to 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->