### PR TITLE
chore(zap): add ignore rules for accepted findings

### DIFF
--- a/.github/workflows/dast-scan.yml
+++ b/.github/workflows/dast-scan.yml
@@ -17,3 +17,4 @@ jobs:
       target_url: "https://numveil.tehwolf.de"
       scan_type: "full"
       max_duration_minutes: "45"
+      rules_file: ".zap/rules.tsv"

--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -1,0 +1,13 @@
+# ZAP DAST Ignore Rules
+
+Rules suppressed in `.zap/rules.tsv` with justification:
+
+| Rule ID | Name | Reason |
+|---------|------|--------|
+| 10035 | Strict-Transport-Security Header Not Set | HSTS is configured in Cloudflare (SSL/TLS → Edge Certificates → HSTS). ZAP scans the HTTP→HTTPS redirect path and does not see the header Cloudflare injects on HTTPS responses. |
+| 10055 | CSP: style-src unsafe-inline / Missing Directives | `style-src unsafe-inline` is required by Angular. `form-action` and `base-uri` are explicitly defined in the CSP — ZAP flags these as informational when `default-src` has no fallback for them. |
+| 10109 | Modern Web Application | Informational finding — ZAP detected a SPA. Not a vulnerability. |
+| 10015 | Re-examine Cache-control Directives | Informational finding about cache headers. Not a vulnerability. |
+| 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
+| 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
+| 40025 | Proxy Disclosure | Cloudflare's `server` header reveals proxy presence. Suppression requires a paid Cloudflare plan — accepted risk. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,7 @@
+10035	IGNORE	HSTS not set — handled by Cloudflare at TLS termination, not nginx
+10055	IGNORE	CSP style-src unsafe-inline required by Angular; form-action and base-uri are explicitly set
+10109	IGNORE	Modern Web Application — informational only, not a vulnerability
+10015	IGNORE	Cache-control directives — informational only, not a vulnerability
+10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
+10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
+40025	IGNORE	Proxy Disclosure — Cloudflare server header cannot be suppressed without a paid Cloudflare plan

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary

Adds `.zap/rules.tsv` to suppress ZAP findings that are either false positives or accepted risks, and `.zap/rules.md` documenting the justification for each suppression.

See `.zap/rules.md` for full reasoning per rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for security scan suppression rules with justifications.

* **Chores**
  * Enhanced automated security scanning configuration with explicit rules file settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->