### PR TITLE
chore(zap): add Retrieved from Cache to ignore rules

### DIFF
--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -11,3 +11,4 @@ Rules suppressed in `.zap/rules.tsv` with justification:
 | 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
 | 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
 | 40025 | Proxy Disclosure | Cloudflare's `server` header reveals proxy presence. Suppression requires a paid Cloudflare plan — accepted risk. |
+| 10050 | Retrieved from Cache | Cloudflare CDN caching behavior. Not a vulnerability. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -5,3 +5,4 @@
 10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
 10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
 40025	IGNORE	Proxy Disclosure — Cloudflare server header cannot be suppressed without a paid Cloudflare plan
+10050	IGNORE	Retrieved from Cache — Cloudflare CDN caching behavior, not a vulnerability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
Adds rule 10050 (Retrieved from Cache) to ZAP ignore rules — Cloudflare CDN caching behavior, not a vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Patch Release**
  * Version bumped to 2.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->