### PR TITLE
chore(zap): ignore User Agent Fuzzer finding

### DIFF
--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -12,3 +12,4 @@ Rules suppressed in `.zap/rules.tsv` with justification:
 | 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
 | 40025 | Proxy Disclosure | Cloudflare's `server` header reveals proxy presence. Suppression requires a paid Cloudflare plan — accepted risk. |
 | 10050 | Retrieved from Cache | Cloudflare CDN caching behavior. Not a vulnerability. |
+| 10104 | User Agent Fuzzer | Static Angular app serves identical content regardless of user agent. Not a vulnerability. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -6,3 +6,4 @@
 10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
 40025	IGNORE	Proxy Disclosure — Cloudflare server header cannot be suppressed without a paid Cloudflare plan
 10050	IGNORE	Retrieved from Cache — Cloudflare CDN caching behavior, not a vulnerability
+10104	IGNORE	User Agent Fuzzer — static Angular app responds identically to all user agents, not a vulnerability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Adds rule 10104 (User Agent Fuzzer) to `.zap/rules.tsv`
- Static Angular app responds identically to all user agents — not a vulnerability
- Updates `.zap/rules.md` with justification

## Test plan
- [ ] Merge PR
- [ ] Trigger DAST scan manually to verify no new findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version from **2.1.3** to **2.1.4**.
  * Updated security scan exclusion notes to include two additional accepted findings, reflecting expected CDN caching behavior and unchanged responses across user agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->