### PR TITLE
feat(lighthouse): add weekly lighthouse audit scan

### DIFF
--- a/.github/workflows/lighthouse-scan.yml
+++ b/.github/workflows/lighthouse-scan.yml
@@ -1,0 +1,16 @@
+name: weekly lighthouse scan
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    name: external workflow
+    uses: tehw0lf/workflows/.github/workflows/lighthouse-scan.yml@main
+    permissions:
+      contents: read
+      issues: write
+    with:
+      target_url: "https://numveil.tehwolf.de"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Adds weekly Lighthouse audit running every Monday at 04:00 UTC
- Uses reusable workflow from `tehw0lf/workflows`
- Reports Performance, Accessibility, Best Practices and SEO scores as Step Summary
- Informational only, does not block merges