### PR TITLE
fix(nginx): add caching and allow framing from tehwolf.de

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,6 +1,7 @@
 FROM nginx:alpine-slim
 RUN apk upgrade --no-cache
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY dist/numveil/browser /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,14 +24,7 @@ http {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Cross-Origin-Embedder-Policy "require-corp" always;
-        add_header Cross-Origin-Opener-Policy "same-origin" always;
-        add_header Cross-Origin-Resource-Policy "same-origin" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        include /etc/nginx/security-headers.conf;
 
         location / {
             root /usr/share/nginx/html;
@@ -43,14 +36,7 @@ http {
             root /usr/share/nginx/html;
             expires 1y;
             add_header Cache-Control "public, immutable";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-            add_header X-Frame-Options "SAMEORIGIN" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "require-corp" always;
-            add_header Cross-Origin-Opener-Policy "same-origin" always;
-            add_header Cross-Origin-Resource-Policy "same-origin" always;
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            include /etc/nginx/security-headers.conf;
             access_log off;
         }
 
@@ -58,14 +44,7 @@ http {
             root /usr/share/nginx/html;
             expires 7d;
             add_header Cache-Control "public";
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-            add_header X-Frame-Options "SAMEORIGIN" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-            add_header Cross-Origin-Embedder-Policy "require-corp" always;
-            add_header Cross-Origin-Opener-Policy "same-origin" always;
-            add_header Cross-Origin-Resource-Policy "same-origin" always;
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            include /etc/nginx/security-headers.conf;
             access_log off;
         }
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,18 +1,31 @@
 events {
-  worker_connections  1024;  ## Default: 1024
+  worker_connections  1024;
 }
 
 http {
 
-    ## use mime types
     include /etc/nginx/mime.types;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_types
+      text/plain
+      text/css
+      text/javascript
+      application/javascript
+      application/x-javascript
+      application/xml
+      application/json
+      application/ld+json;
 
      server {
 
         listen 80;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self';" always;
-        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
         add_header Cross-Origin-Embedder-Policy "require-corp" always;
@@ -22,26 +35,38 @@ http {
 
         location / {
             root /usr/share/nginx/html;
-            index  index.html;
-            ## without this our .css are not loaded
+            index index.html;
             try_files $uri $uri/ /index.html?$query_string;
         }
+
+        location ~* \.(js|css)$ {
+            root /usr/share/nginx/html;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            access_log off;
+        }
+
+        location ~* \.(?:woff2?|svg|ico|png|jpg|jpeg|gif|webp)$ {
+            root /usr/share/nginx/html;
+            expires 7d;
+            add_header Cache-Control "public";
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            access_log off;
+        }
     }
-
-    ## enable gzip compression
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 256;
-    gzip_proxied any;
-
-    gzip_types
-      ## text/html is always compressed : https://nginx.org/en/docs/http/ngx_http_gzip_module.html
-      text/plain
-      text/css
-      text/javascript
-      application/javascript
-      application/x-javascript
-      application/xml
-      application/json
-      application/ld+json;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,8 @@
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Add nginx caching location blocks: js/css with 1y immutable, assets with 7d
- Allow \`frame-ancestors 'self' https://tehwolf.de\` so previews work on tehwolf.de
- Change \`X-Frame-Options\` from \`DENY\` to \`SAMEORIGIN\`

## Test plan
- [ ] Static assets are served with Cache-Control immutable headers
- [ ] App is embeddable in tehwolf.de preview iframe
- [ ] No CSP errors in browser console