### PR TITLE
chore: remove nx cloud integration

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -133,7 +133,6 @@
       "typeSeparator": "."
     }
   },
-  "nxCloudId": "694877641e90ceeddabf06d3",
   "analytics": false,
   "migrate": {
     "agentic": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Remove `nxCloudId` from `nx.json`
- Bump version to 2.1.9