### PR TITLE
fix(csp): add unsafe-hashes and Angular Material sha256 to script-src

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- Add `'unsafe-hashes'` and both Angular Material SHA256 hashes to `script-src` to allow `this.media='all'` inline event handler
- Fixes missing styles on all Angular Material apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened browser security policies by tightening script execution rules in the Content Security Policy.
  - Updated the package version to **2.1.10**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->