### PR TITLE
fix(csp): move Angular Material hashes to script-src

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; script-src-attr 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- Angular Material sets `media='all'` via an inline script element (not an event handler attribute), which is governed by `script-src`, not `script-src-attr`
- Previous PR #50 moved hashes to `script-src-attr` on CodeRabbit's suggestion, but this does not match the actual blocked directive
- Moves `unsafe-hashes` and both sha256 hashes back to `script-src` where they are actually needed

## Test plan
- [ ] Verify CSP error in Firefox console is gone after deploy
- [ ] Verify Angular Material styles load correctly (numveil UI looks correct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **2.1.11**.
* **Bug Fixes**
  * Updated the site’s security policy to better handle inline script-related behavior while keeping the existing protections in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->