### PR TITLE
ci(lighthouse): set score thresholds based on local audit

### DIFF
--- a/.github/workflows/lighthouse-scan.yml
+++ b/.github/workflows/lighthouse-scan.yml
@@ -14,3 +14,7 @@ jobs:
       issues: write
     with:
       target_url: "https://numveil.tehwolf.de"
+      min_performance: 95
+      min_accessibility: 90
+      min_best_practices: 95
+      min_seo: 80

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Sets realistic Lighthouse score thresholds based on local `npx lighthouse` audit (perf 98, a11y 96, bp 100, seo 82)
- Thresholds with ~5 point buffer: perf≥95, a11y≥90, best-practices≥95, seo≥80
- Goal: tighten thresholds incrementally as scores improve toward 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 2.1.12.
* **Bug Fixes**
  * Improved Lighthouse scan checks by adding minimum score thresholds for performance, accessibility, best practices, and SEO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->