### PR TITLE
fix(seo): add meta description, robots.txt and raise lighthouse thresholds

### DIFF
--- a/.github/workflows/lighthouse-scan.yml
+++ b/.github/workflows/lighthouse-scan.yml
@@ -15,6 +15,6 @@ jobs:
     with:
       target_url: "https://numveil.tehwolf.de"
       min_performance: 70
-      min_accessibility: 90
-      min_best_practices: 95
-      min_seo: 80
+      min_accessibility: 100
+      min_best_practices: 100
+      min_seo: 100

--- a/apps/numveil/public/robots.txt
+++ b/apps/numveil/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/apps/numveil/src/index.html
+++ b/apps/numveil/src/index.html
@@ -5,6 +5,7 @@
     <title>Numveil</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Numveil – a real-time multiplayer number guessing game built with Angular and NestJS." />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.13",
+      "version": "2.1.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Add `meta description` to `apps/numveil/src/index.html`
- Add `apps/numveil/public/robots.txt` (included via assets glob in `project.json`; was missing so SPA served HTML at `/robots.txt`)
- Raise lighthouse thresholds: `min_accessibility` 90→100, `min_best_practices` 95→100, `min_seo` 80→100

## Test plan
- [ ] `/robots.txt` returns valid content (not HTML)
- [ ] Lighthouse CI runs green with new thresholds after deploy
- [ ] SEO score reaches 100%