### PR TITLE
perf(numveil): switch to zoneless, remove @angular/animations, enable source maps

### DIFF
--- a/apps/numveil/project.json
+++ b/apps/numveil/project.json
@@ -13,7 +13,7 @@
         "outputPath": "dist/numveil",
         "index": "apps/numveil/src/index.html",
         "browser": "apps/numveil/src/main.ts",
-        "polyfills": ["zone.js"],
+        "polyfills": [],
         "tsConfig": "apps/numveil/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
         "assets": [
@@ -39,7 +39,8 @@
               "maximumError": "4kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "sourceMap": true
         },
         "development": {
           "optimization": false,

--- a/apps/numveil/src/app/app.config.ts
+++ b/apps/numveil/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import {
   APP_INITIALIZER,
   ApplicationConfig,
-  provideZoneChangeDetection,
+  provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
@@ -9,7 +9,7 @@ import { ConfigService } from './services/config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideZonelessChangeDetection(),
     provideRouter(appRoutes),
     {
       provide: APP_INITIALIZER,

--- a/apps/numveil/src/test-setup.ts
+++ b/apps/numveil/src/test-setup.ts
@@ -5,6 +5,6 @@ globalThis.ngJest = {
     errorOnUnknownProperties: true,
   },
 };
-import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+import { setupZonelessTestEnv } from 'jest-preset-angular/setup-env/zoneless';
 
-setupZoneTestEnv();
+setupZonelessTestEnv();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.14",
+      "version": "2.1.15",
       "license": "MIT",
       "dependencies": {
-        "@angular/animations": "22.0.2",
         "@angular/common": "22.0.2",
         "@angular/compiler": "22.0.2",
         "@angular/core": "22.0.2",
@@ -492,22 +491,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.2.tgz",
-      "integrity": "sha512-l9lVG9k+baFMWXNsFUxwmxQaUZMkpkTn3vRpa1hs/vABzT/KnaDeweDtvvkS0NS1RYJenoxhONlMNEWuJ4VR1A==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.2"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",
@@ -13,7 +13,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/common": "22.0.2",
     "@angular/compiler": "22.0.2",
     "@angular/core": "22.0.2",


### PR DESCRIPTION
## Summary

- Switch from `provideZoneChangeDetection` to `provideZonelessChangeDetection()` — removes zone.js polyfill entirely
- Remove `@angular/animations` dependency (not used anywhere in production code)
- Enable `sourceMap: true` in production build configuration
- Update test setup to `setupZonelessTestEnv()`
- **Initial total: 284 kB → 245 kB (−39 kB / −14%)**

## Test plan

- [x] `npx nx run-many -t lint,test` — 47/47 tests pass, lint clean
- [x] `npm run build` — build successful, bundle size reduced