### PR TITLE
fix(a11y): add main landmark and wrap router-outlet

### DIFF
--- a/apps/numveil/src/app/app.component.html
+++ b/apps/numveil/src/app/app.component.html
@@ -1,1 +1,3 @@
-<router-outlet></router-outlet>
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.15",
+      "version": "2.1.16",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Wrap `<router-outlet>` in `<main>` landmark element
- Fixes Lighthouse `landmark-one-main` audit (A11y score was 96%)

## Test plan
- [x] `npx nx run-many -t lint,test,build` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now uses a newer rendering approach for smoother interactions.
  * The main content is now wrapped in a semantic page container for improved structure.

* **Bug Fixes**
  * Updated production build settings to include source maps for easier issue diagnosis.
  * Adjusted test setup to match the latest app runtime behavior.

* **Chores**
  * Bumped the app version to 2.1.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->