### PR TITLE
fix(ci): pin action SHAs in security-scan.yml, bump version

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download latest dist artifacts from CI
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: build-projects.yml
           name: dist
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload artifacts for scanning
         if: hashFiles('dist/**/*') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@numveil/source",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@numveil/source",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "license": "MIT",
   "scripts": {
     "affected:e2e": "nx affected:e2e",


### PR DESCRIPTION
## Summary
- Pins `dawidd6/action-download-artifact@v6` and `actions/upload-artifact@v4` to full commit SHAs in `security-scan.yml`, resolving the Semgrep `github-actions-mutable-action-tag` finding.
- Bumps package version (required for `nx affected` artifact tagging in this repo's CI).
- No code change needed for the `insecure-randomness` alerts on `app.gateway.ts`: the flagged lines already use `crypto.randomInt`/`crypto.randomBytes` (introduced in 6980dff), not `Math.random()`. These alerts are stale and should auto-close on the next scan.
- No code change needed for `exported_activity` in `AndroidManifest.xml`: already suppressed with a documented `nosemgrep` justification (MainActivity export required for Android 12+ launcher intent-filter).

## Test plan
- [x] `nx run-many -t lint,test,build --projects=api,numveil` passes locally
- [ ] CI passes
- [ ] Confirm stale alerts auto-close after next Semgrep scan